### PR TITLE
Change event from select to selectItem in menus (Breaking)

### DIFF
--- a/docs/public/pages/autocomplete/DefaultAutocomplete.js
+++ b/docs/public/pages/autocomplete/DefaultAutocomplete.js
@@ -32,7 +32,7 @@ const onInput = (e) => {
   searchText(e.target.value);
 };
 
-const onSelect = (e) => {
+const onSelectItem = (e) => {
   if (e.detail) {
     const { value } = e.detail;
     searchText(value);
@@ -59,7 +59,7 @@ export default class Example {
       <${Center}>
         <${FieldLayout} width="300px">
           <label for="default-autocomplete">Planet</label>
-          <${Autocomplete} id="default-autocomplete" onSelect=${onSelect}>
+          <${Autocomplete} id="default-autocomplete" onSelectItem=${onSelectItem}>
             <${AutocompleteInput} .value=${searchText()} onInput=${onInput} />
             <${AutocompletePopup}>${this.renderItems()}<//>
           <//>

--- a/docs/public/pages/autocomplete/Placement.js
+++ b/docs/public/pages/autocomplete/Placement.js
@@ -32,7 +32,7 @@ const onInput = (e) => {
   searchText(e.target.value);
 };
 
-const onSelect = (e) => {
+const onSelectItem = (e) => {
   if (e.detail) {
     const { value } = e.detail;
     searchText(value);
@@ -62,7 +62,7 @@ export default class Example {
           <${Autocomplete}
             id="placement-autocomplete"
             placement="top-stretch"
-            onSelect=${onSelect}
+            onSelectItem=${onSelectItem}
           >
             <${AutocompleteInput} .value=${searchText()} onInput=${onInput} />
             <${AutocompletePopup}>${this.renderItems()}<//>

--- a/docs/public/pages/menu/DefaultMenu.js
+++ b/docs/public/pages/menu/DefaultMenu.js
@@ -10,7 +10,7 @@ import {
 
 export default class Example {
   constructor() {
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { key, value } = e.detail;
       alert(`${key}:${value}`);
     };
@@ -19,7 +19,7 @@ export default class Example {
   render() {
     return html`
       <${Center}>
-        <${Menu} onSelect=${this.onSelect}>
+        <${Menu} onSelectItem=${this.onSelectItem}>
           <${MenuButton}>Go to planet<//>
           <${MenuPopup}>
             <${MenuItem} key="mercury" value=${0}>Mercury<//>

--- a/docs/public/pages/menu/NestedMenu.js
+++ b/docs/public/pages/menu/NestedMenu.js
@@ -70,7 +70,7 @@ export default class Example {
   constructor() {
     this.model = new MenuModel({ id: "nested-menu" });
 
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { key, value } = e.detail;
       const menu = menus[key];
 
@@ -107,7 +107,7 @@ export default class Example {
       <${Center}>
         <${CustomMenu}
           model=${this.model}
-          onSelect=${this.onSelect}
+          onSelectItem=${this.onSelectItem}
           onClose=${this.onClose}
         >
           <${MenuButton}>Go to space<//>

--- a/docs/public/pages/menu/Placement.js
+++ b/docs/public/pages/menu/Placement.js
@@ -10,7 +10,7 @@ import {
 
 export default class Example {
   constructor() {
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { key, value } = e.detail;
       alert(`${key}:${value}`);
     };
@@ -19,7 +19,7 @@ export default class Example {
   render() {
     return html`
       <${Center} style="margin-top: 140px">
-        <${Menu} onSelect=${this.onSelect} placement="top-start">
+        <${Menu} onSelectItem=${this.onSelectItem} placement="top-start">
           <${MenuButton}>Go to planet<//>
           <${MenuPopup}>
             <${MenuItem} key="mercury" value=${0}>Mercury<//>

--- a/docs/public/pages/select/DefaultSelect.js
+++ b/docs/public/pages/select/DefaultSelect.js
@@ -26,7 +26,7 @@ const selected = observable(options[0]);
 
 export default class Example {
   constructor() {
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { value } = e.detail;
       selected(value);
     };
@@ -51,7 +51,7 @@ export default class Example {
       <${Center}>
         <${FieldLayout} width="300px">
           <label for="default-select">Select a planet</label>
-          <${Select} id="default-select" onSelect=${this.onSelect}>
+          <${Select} id="default-select" onSelectItem=${this.onSelectItem}>
             <${SelectInput} .value=${selected().value}>${selected().label}<//>
             <${SelectPopup}>${this.renderItems()}<//>
           <//>

--- a/docs/public/pages/select/Disabled.js
+++ b/docs/public/pages/select/Disabled.js
@@ -26,7 +26,7 @@ const selected = observable(options[0]);
 
 export default class Example {
   constructor() {
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { value } = e.detail;
       selected(value);
     };
@@ -51,7 +51,7 @@ export default class Example {
       <${Center}>
         <${FieldLayout} width="300px">
           <label for="disabled-select">Select a planet</label>
-          <${Select} id="disabled-select" onSelect=${this.onSelect}>
+          <${Select} id="disabled-select" onSelectItem=${this.onSelectItem}>
             <${SelectInput} disabled .value=${selected().value}>
               ${selected().label}
             <//>

--- a/docs/public/pages/select/NestedSelect.js
+++ b/docs/public/pages/select/NestedSelect.js
@@ -84,7 +84,7 @@ export default class Example {
       selected: selected(),
     });
 
-    this.onSelect = (e) => {
+    this.onSelectItem = (e) => {
       const { key, value } = e.detail;
       const menuItems = options[key];
 
@@ -119,7 +119,7 @@ export default class Example {
           <label for="default-select">Select a celestial body</label>
           <${CustomSelect}
             model=${this.model}
-            onSelect=${this.onSelect}
+            onSelectItem=${this.onSelectItem}
             placement="top-stretch"
           >
             <${SelectInput} .value=${selected().value}>${selected().label}<//>

--- a/packages/components/src/Menu/v0/Menu.js
+++ b/packages/components/src/Menu/v0/Menu.js
@@ -36,8 +36,8 @@ export class CustomMenu {
     };
 
     this.onSelectItem = (e) => {
-      const onSelect = this.props.onSelect;
-      if (onSelect) onSelect(e);
+      const onSelectItem = this.props.onSelectItem;
+      if (onSelectItem) onSelectItem(e);
       if (!e.defaultPrevented) this.model.hideMenu();
     };
 

--- a/packages/styleguide/src/components/ColorSchemeSelector.js
+++ b/packages/styleguide/src/components/ColorSchemeSelector.js
@@ -22,7 +22,7 @@ const selected = computed(() =>
   options.find((option) => option.key === colorScheme()),
 );
 
-const onSelect = (e) => {
+const onSelectItem = (e) => {
   colorScheme(e.detail.key);
 };
 
@@ -48,7 +48,7 @@ export class ColorSchemeSelector {
       h("label", { for: "styleguide-color-scheme" }, "Color scheme"),
       h(
         Select,
-        { id: "styleguide-color-scheme", onSelect: onSelect },
+        { id: "styleguide-color-scheme", onSelectItem: onSelectItem },
         h(SelectInput, {}, selected().label),
         h(SelectPopup, {}, this.renderItems()),
       ),

--- a/packages/styleguide/src/components/ThemeSelector.js
+++ b/packages/styleguide/src/components/ThemeSelector.js
@@ -24,7 +24,7 @@ const selected = computed(() =>
   themes.find((theme) => theme.key === selectedKey()),
 );
 
-const onSelect = (e) => {
+const onSelectItem = (e) => {
   selectedKey(e.detail.key);
 };
 
@@ -52,7 +52,7 @@ export class ThemeSelector {
       h("label", { for: "styleguide-theme" }, "Theme"),
       h(
         Select,
-        { id: "styleguide-theme", onSelect: onSelect },
+        { id: "styleguide-theme", onSelectItem: onSelectItem },
         h(SelectInput, {}, selected().label),
         h(SelectPopup, {}, this.renderItems()),
       ),


### PR DESCRIPTION
You have to use `onSelectItem` instead of `onSelect` - the reason for this change is that the dom already defines a `select` event for text. 